### PR TITLE
Handle file upload alternative path and edge cases

### DIFF
--- a/manager/.mypy.ini
+++ b/manager/.mypy.ini
@@ -4,3 +4,6 @@ strict = True
 
 [mypy-minio.*]
 ignore_missing_imports = True
+
+[mypy-psycopg2.*]
+ignore_missing_imports = True

--- a/manager/api/responses/file.py
+++ b/manager/api/responses/file.py
@@ -3,6 +3,7 @@
 
 from domain.file import FileMetadata
 from fastapi import Response, status
+from fastapi.responses import JSONResponse
 
 
 class FileResponseMetadata(Response):
@@ -26,3 +27,15 @@ class FileResponseMetadata(Response):
         description = metadata.get_description()
         if description:
             self.headers["x-description"] = description
+
+
+class FileAlreadyExistsResponse(JSONResponse):
+    """HTTP error response for when file already exists."""
+
+    def __init__(self) -> None:
+        """Creates a client error response with a descriptive message."""
+        JSONResponse.__init__(
+            self,
+            content={"message": "A file with the same name already exists"},
+            status_code=status.HTTP_409_CONFLICT,
+        )

--- a/manager/api/routers/files.py
+++ b/manager/api/routers/files.py
@@ -1,7 +1,8 @@
 """Files router module."""
 
 from api.converters.file import extract_content, extract_metadata
-from api.responses.file import FileResponseMetadata
+from api.responses.file import FileAlreadyExistsResponse, FileResponseMetadata
+from exceptions.file import FileAlreadyExistsError
 from factories.filesystem import get_filesystem
 from fastapi import APIRouter, Header, Response, status, UploadFile
 from typing import Annotated
@@ -23,6 +24,9 @@ async def post(
     metadata = extract_metadata(file, x_description)
     content = extract_content(file)
 
-    await fs.save(metadata, content)
+    try:
+        await fs.save(metadata, content)
 
-    return FileResponseMetadata(metadata, status_code=status.HTTP_201_CREATED)
+        return FileResponseMetadata(metadata, status_code=status.HTTP_201_CREATED)
+    except FileAlreadyExistsError:
+        return FileAlreadyExistsResponse()

--- a/manager/domain/filesystem.py
+++ b/manager/domain/filesystem.py
@@ -1,7 +1,6 @@
 """Module for managing file storage."""
 
 
-import asyncio
 from .file import FileMetadata, ReadableFile
 from interfaces.contentdb import ContentDB
 from interfaces.filesystem import Filesystem
@@ -38,6 +37,6 @@ class MixedFilesystem(Filesystem):
         # FIXME this is an overly optimistic implementation,
         # there are use cases which aren't properly covered here
         id = metadata.get_filename()
-        await asyncio.gather(
-            self._metaDB.save(id, metadata), self._contentDB.save(id, contents)
-        )
+
+        await self._metaDB.save(id, metadata)
+        await self._contentDB.save(id, contents)

--- a/manager/exceptions/__init__.py
+++ b/manager/exceptions/__init__.py
@@ -1,0 +1,1 @@
+"""Definitions for domain exceptions."""

--- a/manager/exceptions/base.py
+++ b/manager/exceptions/base.py
@@ -1,0 +1,14 @@
+"""Base exceptions.
+
+All domain exceptions should inherit from one of the classes contained here.
+"""
+
+
+class DomainException(Exception):
+    """Base domain exception.
+
+    All domain errors extend this class,
+    either directly or indirectly.
+    """
+
+    pass

--- a/manager/exceptions/file.py
+++ b/manager/exceptions/file.py
@@ -1,0 +1,10 @@
+"""File related exceptions."""
+
+
+from .base import DomainException
+
+
+class FileAlreadyExistsError(DomainException):
+    """File of the same name already exists."""
+
+    pass

--- a/manager/interfaces/metadb.py
+++ b/manager/interfaces/metadb.py
@@ -15,5 +15,9 @@ class MetaDB(ABC):
         Args:
             id: The unique file identifier.
             metadata: The metadata to be persisted.
+
+        Raises:
+            FileAlreadyExistsError: Metadata for the specified id already
+            exists in the database.
         """
         pass

--- a/manager/tests/unit/domain/filesystem.py
+++ b/manager/tests/unit/domain/filesystem.py
@@ -1,5 +1,6 @@
 from domain.file import FileMetadata, ReadableFile
 from domain.filesystem import MixedFilesystem
+from exceptions.file import FileAlreadyExistsError
 from interfaces.contentdb import ContentDB
 from interfaces.metadb import MetaDB
 from unittest import IsolatedAsyncioTestCase, main
@@ -51,6 +52,13 @@ class TestMixedFilesystem_Save(IsolatedAsyncioTestCase):
         await self.fs.save(self.file_metadata, self.file_contents)
         self.metaDB.save_mock.assert_called_with("test_file.txt", self.file_metadata)
         self.contentDB.save_mock.assert_called_with("test_file.txt", self.file_contents)
+
+    async def test_should_fail_when_file_of_same_name_already_exists(self) -> None:
+        self.metaDB.save_mock.side_effect = FileAlreadyExistsError()
+        with self.assertRaises(FileAlreadyExistsError):
+            await self.fs.save(self.file_metadata, self.file_contents)
+        self.metaDB.save_mock.assert_called_with("test_file.txt", self.file_metadata)
+        self.contentDB.save_mock.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #24 

I could only think of a single alternative path. All edge cases I could think of were related to handling unexpected PostgreSQL or MinIO failures and ensuring operation atomicity, which are things I believe should be handled in a future occasion.